### PR TITLE
fix(vol1-photos): Vertical align the photos to the top

### DIFF
--- a/emails/2024/vol-1-research-cockpit.tsx
+++ b/emails/2024/vol-1-research-cockpit.tsx
@@ -116,7 +116,7 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
             {createTable(dataStewards).map((row) => (
               <Row>
                 {row.map((cell) => (
-                  <Column className="w-1/4 px-2">
+                  <Column className="w-1/4 px-2 align-top">
                     <Img
                       className="w-full object-cover rounded-lg"
                       height={150}


### PR DESCRIPTION
This PR vertically aligns the photos to the top.

![image](https://github.com/user-attachments/assets/edb2f44b-ecf4-4bb4-8063-eb2b0255368b)

Fixes #10 