### PR TITLE
fix(vol1): Add "the" to the CTA button ("Go to the Research Cockpit")

### DIFF
--- a/emails/2024/vol-1-research-cockpit.tsx
+++ b/emails/2024/vol-1-research-cockpit.tsx
@@ -108,7 +108,7 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
               className="bg-white box-border rounded-md py-3 px-4 text-center font-semibold w-full"
               href="https://tue.atlassian.net/helpcenter/research/"
             >
-              Go to Research Cockpit
+              Go to the Research Cockpit
             </Button>
           </Section>
           <Section>


### PR DESCRIPTION
This PR adds the "the" to the Call-to-Action Button.

Fixes #11 