### PR TITLE
fix(images): deploy static assets with correct basePath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 out/
 .next/
 public/emails/
+public/static/
 .react-email/

--- a/emails/2026/vol-2-rdm-policy.tsx
+++ b/emails/2026/vol-2-rdm-policy.tsx
@@ -21,7 +21,7 @@ import { createTable } from "../../lib/createTable";
 
 const baseUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
-  : "";
+  : process.env.NEXT_PUBLIC_BASE_PATH || "/tue-ds-newsletter";
 
 type NewsletterEmailProps = {
   unsubscribeUrl: string;

--- a/scripts/build-emails.ts
+++ b/scripts/build-emails.ts
@@ -11,6 +11,13 @@ type EmailEntry = { slug: string; title: string };
 async function main() {
   fs.mkdirSync(outDir, { recursive: true });
 
+  const staticSrc = path.resolve(emailsDir, "static");
+  const staticDst = path.resolve(process.cwd(), "public/static");
+  if (fs.existsSync(staticSrc)) {
+    fs.cpSync(staticSrc, staticDst, { recursive: true });
+    console.log("  ✓ static assets copied");
+  }
+
   const emailFiles = scanEmails(emailsDir);
 
   const manifest: EmailEntry[] = [];


### PR DESCRIPTION
Static images in emails/static/ were never deployed because build-emails.ts skipped the static dir, and image src URLs resolved against the origin root (missing /tue-ds-newsletter basePath) since the email HTML is loaded via iframe srcDoc.

- Copy emails/static/ to public/static/ during build so next build emits them to out/static/ and they get deployed
- Fall back to NEXT_PUBLIC_BASE_PATH (or /tue-ds-newsletter) for baseUrl so image URLs resolve correctly on GitHub Pages and PR previews
- Ignore generated public/static/