### PR TITLE
fix(vol2): Fix Vol. 2 images not loading in react-email dev preview

### DIFF
--- a/emails/2026/vol-2-rdm-policy.tsx
+++ b/emails/2026/vol-2-rdm-policy.tsx
@@ -21,7 +21,9 @@ import { createTable } from "../../lib/createTable";
 
 const baseUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
-  : process.env.NEXT_PUBLIC_BASE_PATH || "/tue-ds-newsletter";
+  : process.env.EMAIL_DEV
+    ? ""
+    : process.env.NEXT_PUBLIC_BASE_PATH || "/tue-ds-newsletter";
 
 type NewsletterEmailProps = {
   unsubscribeUrl: string;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.34",
   "private": true,
   "scripts": {
-    "dev": "email dev",
+    "dev": "EMAIL_DEV=1 email dev",
     "build:emails": "tsx scripts/build-emails.ts",
     "build": "yarn build:emails && next build",
     "export": "email export"


### PR DESCRIPTION
The react-email dev server (email dev) serves static assets from ./emails/static at /static/* with no basePath. Vol. 2's baseUrl fell back to the Next.js basePath (/tue-ds-newsletter), so images requested /tue-ds-newsletter/static/RAPS.png, which the dev server couldn't resolve (./emails/tue-ds-newsletter/static/ doesn't exist).

Add a dev-only EMAIL_DEV flag in the dev script; when set, baseUrl returns  so images resolve to /static/* in preview. The build path (flag unset) keeps the /tue-ds-newsletter basePath for the exported GitHub Pages site.