### PR TITLE
Render email HTML source with copy-to-clipboard for Copernica

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,75 @@
 # tue-ds-newsletter
 
-A live preview right in your browser so you don't need to keep sending real emails during development.
+A browser preview of the TU/e Research Data Stewards newsletter emails, with
+one-click copy of the rendered HTML source (including absolute image URLs)
+for pasting into [Copernica](https://www.copernica.com/).
+
+The email templates live in [`emails/`](emails) as React Email components.
+They are rendered to HTML, exported as a static Next.js site, and deployed to
+GitHub Pages.
 
 ## Getting Started
 
-First, install the dependencies:
+Install the dependencies:
 
 ```sh
-npm install
-# or
 yarn
 ```
 
-Then, run the development server:
+## Scripts
+
+| Script | Description |
+| --- | --- |
+| `yarn dev` | Start the [react-email](https://react.email/) editor on `localhost:3000` for editing individual email templates. |
+| `yarn build:emails` | Render every email in `emails/` to HTML in `public/emails/` (and copy `emails/static/` to `public/static/`). |
+| `yarn build` | `build:emails` + `next build` → static export to `out/`. |
+| `yarn preview` | Build the export and serve it locally under the production basePath, mirroring the deployed GitHub Pages site. |
+| `yarn export` | Export emails via the react-email CLI. |
+
+## Previewing the deployed site locally
+
+`yarn dev` runs the react-email **editor**, not the exported Next.js site. To
+see the site as it appears on GitHub Pages (sidebar, preview page, HTML
+Source view), use:
 
 ```sh
-npm run dev
-# or
-yarn dev
+yarn preview          # http://localhost:4321/tue-ds-newsletter/
+yarn preview -l 5000  # custom port
 ```
 
-Open [localhost:3000](http://localhost:3000) with your browser to see the result.
+This builds the static export and serves it under the production basePath
+(`/tue-ds-newsletter`) via a temporary symlink root, so asset paths and image
+URLs resolve exactly as they do when deployed.
+
+## Copying the HTML source for Copernica
+
+The deployed preview page has a **Preview / HTML Source** toggle:
+
+1. Open the deployed preview for an email.
+2. Click **HTML Source**.
+3. Click **Copy HTML**.
+4. Paste into Copernica.
+
+Root-relative image paths (`/tue-ds-newsletter/static/...`) are rewritten to
+absolute GitHub Pages URLs (`https://tue-datastewards.github.io/...`) at
+runtime using the current deployment origin, so images load remotely in
+email clients **without needing to be attached**. Copy from the **production**
+site (post-merge) for stable URLs.
+
+## Deployment
+
+The site is deployed to GitHub Pages by two workflows in
+[`.github/workflows/`](.github/workflows):
+
+- `deploy.yml` — on push to `main`, builds and deploys to
+  `https://tue-datastewards.github.io/tue-ds-newsletter/`.
+- `pr-preview.yml` — on PR events, builds with a PR-specific basePath and
+  deploys to `.../pr-preview/pr-<N>/`, posting the preview URL as a comment
+  on the PR.
+
+The production basePath (`/tue-ds-newsletter`) is set in
+[`next.config.js`](next.config.js); the PR-preview workflow overrides it
+via `NEXT_PUBLIC_BASE_PATH`.
 
 ## License
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -73,7 +73,8 @@ body {
 }
 
 .__preview-wrap {
-  height: 100%;
+  flex-grow: 1;
+  min-height: 0;
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -92,4 +93,77 @@ body {
   justify-content: center;
   height: 100%;
   color: #4b5563;
+}
+
+.__email-preview {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.__email-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #000;
+  border-bottom: 1px solid #1f2937;
+  flex-shrink: 0;
+}
+
+.__email-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.__email-tab {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 0;
+  background: transparent;
+  color: #9ca3af;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.__email-tab:hover {
+  background: #111827;
+  color: #fff;
+}
+
+.__email-tab.active {
+  background: #1f2937;
+  color: #fff;
+}
+
+.__email-copy {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid #1f2937;
+  background: #111827;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.__email-copy:hover {
+  background: #1f2937;
+  border-color: #374151;
+}
+
+.__email-source {
+  flex-grow: 1;
+  min-height: 0;
+  overflow: auto;
+  margin: 0;
+  padding: 16px;
+  background: #0a0a0a;
+  color: #e5e7eb;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
 }

--- a/app/preview/[...slug]/email-preview.tsx
+++ b/app/preview/[...slug]/email-preview.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+
+type EmailPreviewProps = {
+  html: string;
+  title: string;
+};
+
+type Mode = "preview" | "source";
+
+export function EmailPreview({ html, title }: EmailPreviewProps) {
+  const [mode, setMode] = useState<Mode>("preview");
+  const [copied, setCopied] = useState(false);
+
+  const copyHtml = async () => {
+    try {
+      await navigator.clipboard.writeText(html);
+    } catch {
+      // Fallback for browsers without the async clipboard API
+      const ta = document.createElement("textarea");
+      ta.value = html;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy");
+      } catch {
+        /* ignore */
+      }
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="__email-preview">
+      <div className="__email-toolbar">
+        <div className="__email-tabs">
+          <button
+            type="button"
+            className={
+              mode === "preview" ? "__email-tab active" : "__email-tab"
+            }
+            onClick={() => setMode("preview")}
+          >
+            Preview
+          </button>
+          <button
+            type="button"
+            className={
+              mode === "source" ? "__email-tab active" : "__email-tab"
+            }
+            onClick={() => setMode("source")}
+          >
+            HTML Source
+          </button>
+        </div>
+        {mode === "source" && (
+          <button
+            type="button"
+            className="__email-copy"
+            onClick={copyHtml}
+            aria-live="polite"
+          >
+            {copied ? "Copied!" : "Copy HTML"}
+          </button>
+        )}
+      </div>
+      {mode === "preview" ? (
+        <div className="__preview-wrap">
+          <iframe
+            className="__preview-iframe"
+            srcDoc={html}
+            title={title}
+          />
+        </div>
+      ) : (
+        <pre className="__email-source">
+          <code>{html}</code>
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/app/preview/[...slug]/email-preview.tsx
+++ b/app/preview/[...slug]/email-preview.tsx
@@ -9,17 +9,34 @@ type EmailPreviewProps = {
 
 type Mode = "preview" | "source";
 
+// Rewrite root-relative image URLs (e.g. /tue-ds-newsletter/static/RAPS.png)
+// to absolute URLs against the current deployment origin, so the copied HTML
+// loads images from the GitHub Pages site in email clients like Copernica
+// (which can't resolve root-relative paths and would otherwise need images
+// attached). Leaves already-absolute (https://) and protocol-relative (//)
+// URLs untouched.
+const toAbsoluteUrls = (html: string): string => {
+  if (typeof window === "undefined") return html;
+  const origin = window.location.origin;
+  return html.replace(/src="\/(?!\/)/g, `src="${origin}/`);
+};
+
 export function EmailPreview({ html, title }: EmailPreviewProps) {
   const [mode, setMode] = useState<Mode>("preview");
   const [copied, setCopied] = useState(false);
 
+  // The iframe renders the original (root-relative) HTML, which resolves
+  // against the same origin on the deployed site. The source view + copy use
+  // absolute URLs so the markup is portable when pasted into an email client.
+  const sourceHtml = toAbsoluteUrls(html);
+
   const copyHtml = async () => {
     try {
-      await navigator.clipboard.writeText(html);
+      await navigator.clipboard.writeText(sourceHtml);
     } catch {
       // Fallback for browsers without the async clipboard API
       const ta = document.createElement("textarea");
-      ta.value = html;
+      ta.value = sourceHtml;
       ta.style.position = "fixed";
       ta.style.opacity = "0";
       document.body.appendChild(ta);
@@ -79,7 +96,7 @@ export function EmailPreview({ html, title }: EmailPreviewProps) {
         </div>
       ) : (
         <pre className="__email-source">
-          <code>{html}</code>
+          <code>{sourceHtml}</code>
         </pre>
       )}
     </div>

--- a/app/preview/[...slug]/page.tsx
+++ b/app/preview/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { notFound } from "next/navigation";
+import { EmailPreview } from "./email-preview";
 
 type EmailEntry = { slug: string; title: string };
 
@@ -59,13 +60,5 @@ export default function PreviewPage({
 
   const html = fs.readFileSync(htmlPath, "utf-8");
 
-  return (
-    <div className="__preview-wrap">
-      <iframe
-        className="__preview-iframe"
-        srcDoc={html}
-        title={email.title}
-      />
-    </div>
-  );
+  return <EmailPreview html={html} title={email.title} />;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "EMAIL_DEV=1 email dev",
     "build:emails": "tsx scripts/build-emails.ts",
     "build": "yarn build:emails && next build",
-    "export": "email export"
+    "export": "email export",
+    "preview": "tsx scripts/preview.mjs"
   },
   "dependencies": {
     "@react-email/components": "0.0.25",

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Local preview of the deployed GitHub Pages site.
+//
+// Builds the static export (./out), serves it under the production basePath
+// (/tue-ds-newsletter) via a temporary symlink root, and starts a static
+// server. Mirrors what .github/workflows/deploy.yml produces on main.
+//
+// Usage: yarn preview [-- <serve-args, e.g. -l 4321>]
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BASE_PATH = "/tue-ds-newsletter";
+const DEFAULT_PORT = 4321;
+
+// project root = folder containing this file
+const __filename = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(path.dirname(__filename), "..");
+const outDir = path.join(projectRoot, "out");
+const tmpRoot = path.join(os.tmpdir(), "tue-ds-preview");
+
+function runBuild() {
+  console.log("▶ Building static export (yarn build)...");
+  const res = spawnSync(
+    process.platform === "win32" ? "yarn.cmd" : "yarn",
+    ["build"],
+    { cwd: projectRoot, stdio: "inherit" },
+  );
+  if (res.status !== 0) {
+    console.error("✘ build failed");
+    process.exit(res.status ?? 1);
+  }
+}
+
+function setupSymlinkRoot() {
+  if (!fs.existsSync(path.join(outDir, "index.html"))) {
+    console.error(`✘ ${outDir} has no index.html. Build may have failed.`);
+    process.exit(1);
+  }
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  // out -> tmpRoot/tue-ds-newsletter
+  const linkPath = path.join(tmpRoot, BASE_PATH);
+  fs.symlinkSync(outDir, linkPath, "junction");
+}
+
+function startServer() {
+  // Allow `yarn preview -- -l 5000` to override the port.
+  const passedArgs = process.argv.slice(2);
+  const args = passedArgs.length > 0 ? passedArgs : ["-l", String(DEFAULT_PORT)];
+
+  console.log("\n▶ Serving preview at:");
+  console.log(`   http://localhost:${DEFAULT_PORT}${BASE_PATH}/`);
+  console.log("   (Ctrl+C to stop)\n");
+
+  const child = spawn(
+    process.platform === "win32" ? "npx.cmd" : "npx",
+    ["--yes", "serve", tmpRoot, ...args],
+    { stdio: "inherit", cwd: tmpRoot },
+  );
+
+  const stop = () => {
+    child.kill();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    process.exit(0);
+  };
+  process.on("SIGINT", stop);
+  process.on("SIGTERM", stop);
+  child.on("exit", (code) => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    process.exit(code ?? 0);
+  });
+}
+
+runBuild();
+setupSymlinkRoot();
+startServer();


### PR DESCRIPTION

 - Add a Preview / HTML Source toggle with a Copy HTML button to the email preview page
 - Rewrite root-relative src to absolute GitHub Pages URLs (via window.location.origin) in the copied source so images load remotely in email clients without
   attachments
 - Add yarn preview to build the export and serve it locally under the production basePath, mirroring the deployed site
 - Update the README with the scripts, local preview, and Copernica workflow