### PR TITLE
feat(vol2): Add "View the newsletter on your browser" link on top

### DIFF
--- a/emails/2026/vol-2-rdm-policy.tsx
+++ b/emails/2026/vol-2-rdm-policy.tsx
@@ -41,7 +41,7 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
               href="{webversion}"
               className="text-[#9ca3af] text-xs"
             >
-              View the newsletter on your browser
+              View this newsletter on your browser
             </Link>
           </Section>
           <Section className="bg-[#823969] text-white px-4 py-[20px]">

--- a/emails/2026/vol-2-rdm-policy.tsx
+++ b/emails/2026/vol-2-rdm-policy.tsx
@@ -36,6 +36,14 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
       <Preview>Research Data Stewards Newsletter Vol. 2</Preview>
       <Body className="bg-[#313846]">
         <Container>
+          <Section className="text-center py-2">
+            <Link
+              href="{webversion}"
+              className="text-[#9ca3af] text-xs"
+            >
+              View the newsletter on your browser
+            </Link>
+          </Section>
           <Section className="bg-[#823969] text-white px-4 py-[20px]">
             <Row>
               <Column width="41">


### PR DESCRIPTION
Add a link at the top of the Vol. 2 email using the Copernica `{webversion}` token so recipients can open the newsletter in their browser.