### PR TITLE
fix(vol2): Wrap email in full-width Section for dark background

### DIFF
--- a/emails/2026/vol-2-rdm-policy.tsx
+++ b/emails/2026/vol-2-rdm-policy.tsx
@@ -35,6 +35,7 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
       <Head />
       <Preview>Research Data Stewards Newsletter Vol. 2</Preview>
       <Body className="bg-[#313846]">
+        <Section className="bg-[#313846]">
         <Container>
           <Section className="text-center py-2">
             <Link
@@ -348,6 +349,7 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
             </Link>
           </Text>
         </Container>
+        </Section>
       </Body>
     </Html>
   </Tailwind>


### PR DESCRIPTION
The dark frame color (#313846) was set only on `<Body>`, which ESPs like Copernica discard when pasting email HTML, so the sent email showed a transparent/missing background.

Wrap all Containers in a full-width `<Section>` that carries the same background, so the dark frame survives ESP body-content extraction and renders in email clients. `<Body>` keeps the background as a fallback.