### PR TITLE
fix(vol2): Apply a white background to the OSCE logo

### DIFF
--- a/emails/2026/vol-2-rdm-policy.tsx
+++ b/emails/2026/vol-2-rdm-policy.tsx
@@ -223,7 +223,7 @@ export const NewsletterEmail = ({ unsubscribeUrl }: NewsletterEmailProps) => (
                   src={`${baseUrl}/static/osc-eindhoven-logo.svg`}
                   width={200}
                   alt="Open Science Community Eindhoven logo"
-                  className="mx-auto my-4"
+                  className="mx-auto my-4 bg-white p-4 rounded-lg"
                 />
               </Link>
               <Button


### PR DESCRIPTION
The OSCE logo SVG has a transparent background. Apply `bg-white` directly to the image (with padding and rounded corners) so the white background travels with the image and renders reliably in email clients, even if the surrounding container's background is dropped by the ESP.